### PR TITLE
Update ExTwitter and fix deprecation warnings.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,7 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-config :ex_twitter, :oauth, [
+config :extwitter, :oauth, [
   consumer_key: System.get_env("TWITTER_CONSUMER_KEY"),
   consumer_secret: System.get_env("TWITTER_CONSUMER_SECRET"),
   access_token: System.get_env("TWITTER_ACCESS_TOKEN"),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -32,4 +32,4 @@ config :elixir_friends, ElixirFriends.Repo,
   username: "postgres",
   password: "postgres",
   database: "elixir_friends_dev",
-  size: 10 # The amount of database connections in the pool
+  pool_size: 10 # The amount of database connections in the pool

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,4 +16,4 @@ config :elixir_friends, ElixirFriends.Repo,
   username: System.get_env("DATABASE_POSTGRESQL_USERNAME") || "postgres",
   password: System.get_env("DATABASE_POSTGRESQL_PASSWORD") || "postgres",
   database: "elixir_friends_test",
-  size: 1 # Use a single connection for transactional tests
+  pool_size: 1 # Use a single connection for transactional tests

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule ElixirFriends.Mixfile do
       {:phoenix_html, "~> 2.1.0"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:cowboy, "~> 1.0"},
-      {:extwitter, "~> 0.4"},
+      {:extwitter, "~> 0.5.1"},
       {:oauth, github: "tim/erlang-oauth"},
       {:scrivener, "~> 0.12.0"},
       {:honeybadger, "~> 0.3"}

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "ecto": {:hex, :ecto, "0.15.0"},
-  "extwitter": {:hex, :extwitter, "0.5.0"},
+  "extwitter": {:hex, :extwitter, "0.5.1"},
   "fs": {:hex, :fs, "0.9.2"},
   "hackney": {:hex, :hackney, "1.3.2"},
   "honeybadger": {:hex, :honeybadger, "0.3.0"},


### PR DESCRIPTION
I noticed these issues when I was getting the application running locally. Repo `size` has been deprecated in favor of `pool_size` and ExTwitter started using `extwitter` instead of `ex_twitter`.
