### PR TITLE
Fix memory leak

### DIFF
--- a/lib/elixir_friends.ex
+++ b/lib/elixir_friends.ex
@@ -13,7 +13,7 @@ defmodule ElixirFriends do
       supervisor(ElixirFriends.Endpoint, []),
       # Start the Ecto repository
       supervisor(ElixirFriends.Repo, []),
-      worker(Task, [fn -> ElixirFriends.ImageTweetStreamer.stream(term) |> Enum.to_list end])
+      worker(Task, [fn -> ElixirFriends.ImageTweetStreamer.stream(term) |> Stream.run end])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html


### PR DESCRIPTION
I was watching [the Elixir Sips episode 174](http://elixirsips.com/episodes/174_elixir_friends_saving_tweets_with_streams_and_filters.html) and noticed the use of `Enum.to_list/1` to trigger enumeration. That seems problematic as the list will have to contain an unconstrained number of items.

I decided to use `Enum.count/1` even though the integer itself will consume more memory over time. However, the process would have to be very long-lived for this to truly leak.

`Enum.all?(..., fn(x) -> true end)` or `Enum.min/1` might be better although they suffer from not being comprehensible. I'm not sure what would be most idiomatic.

As `ImageTweetStreamer.stream/1` is responsible for processing tweets, maybe the best design is to not make it lazy.

I should point out that I haven't tested my assumption nor have I watched all episodes so this could be addressed later.
